### PR TITLE
Preserve primary key ordering and allow extracting embedded keys from KCQL

### DIFF
--- a/src/main/scala/com/datamountaineer/streamreactor/connect/config/base/traits/KcqlSettings.scala
+++ b/src/main/scala/com/datamountaineer/streamreactor/connect/config/base/traits/KcqlSettings.scala
@@ -70,7 +70,7 @@ trait KcqlSettings extends BaseSettings {
   def getPrimaryKeys(kcql: Set[Kcql] = getKCQL): Map[String, Set[String]] = {
     kcql.toList.map{r =>
       val names: Seq[String] = r.getPrimaryKeys.map(f => f.getName)
-      val set: Set[String] = ListSet(names:_*)
+      val set: Set[String] = ListSet(names.reverse:_*)
       (r.getSource, set)
     }.toMap
   }
@@ -133,7 +133,7 @@ trait KcqlSettings extends BaseSettings {
             case false => key.getName
             case true => key.toString
           }
-        ):_*)
+        ).reverse:_*)
         if (keys.isEmpty) throw new ConfigException(s"${r.getTarget} is set up with upsert, you need primary keys setup")
         (r.getSource, keys)
       }.toMap
@@ -144,7 +144,7 @@ trait KcqlSettings extends BaseSettings {
       .filter(c => c.getWriteMode == WriteModeEnum.UPSERT)
       .map { r =>
         val keyList: List[Field] = r.getPrimaryKeys().toList
-        val keys: Set[Field] = ListSet( keyList:_* )
+        val keys: Set[Field] = ListSet( keyList.reverse:_* )
         if (keys.isEmpty) throw new ConfigException(s"${r.getTarget} is set up with upsert, you need primary keys setup")
         (r.getSource, keys.head.getName)
       }.toMap
@@ -160,7 +160,7 @@ trait KcqlSettings extends BaseSettings {
 
   def getPrimaryKeyCols(kcql: Set[Kcql] = getKCQL): Map[String, Set[String]] = {
     kcql.toList.map(k =>
-      (k.getSource, ListSet(k.getPrimaryKeys.map(p => p.getName):_*))
+      (k.getSource, ListSet(k.getPrimaryKeys.map(p => p.getName).reverse:_*))
     ).toMap
   }
 

--- a/src/test/scala/com/datamountaineer/streamreactor/connect/config/KcqlSettingsTest.scala
+++ b/src/test/scala/com/datamountaineer/streamreactor/connect/config/KcqlSettingsTest.scala
@@ -1,0 +1,75 @@
+/*
+ *  Copyright 2017 Datamountaineer.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.datamountaineer.streamreactor.connect.config
+
+import java.text.SimpleDateFormat
+import java.time.LocalDate
+import java.util
+
+import com.datamountaineer.streamreactor.connect.config.base.traits.KcqlSettings
+import org.apache.kafka.common.config.types.Password
+import org.apache.kafka.connect.data.{Date, Schema, SchemaBuilder, Struct}
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.collection.immutable.ListSet
+
+class KcqlSettingsTest extends WordSpec with Matchers {
+
+  import scala.collection.JavaConverters._
+
+  case class KS(kcql: String) extends KcqlSettings {
+
+    override def connectorPrefix: String = "66686723939"
+    override def getString(key: String): String = key match {
+      case `kcqlConstant` => kcql
+      case _ => null
+    }
+    override def getInt(key: String): Integer = 0
+    override def getBoolean(key: String): java.lang.Boolean = false
+    override def getPassword(key: String): Password = null
+    override def getList(key: String): util.List[String] = List.empty[String].asJava
+  }
+
+  def testUpsertKeys(
+    kcql: String, 
+    expectedKeys: Set[String], 
+    topic: String = "t",
+    preserve: Boolean = false) = {
+    val keys = KS(kcql).getUpsertKeys(preserveFullKeys=preserve)(topic)
+    // get rid of ListSet to avoid ordering issues:
+    keys.toList.toSet shouldBe expectedKeys
+  }
+
+  "KcqlSettings.getUpsertKeys()" should {
+
+    "return 'basename' of key by default" in {
+
+      testUpsertKeys("UPSERT INTO coll SELECT * FROM t PK a", Set("a"))
+      testUpsertKeys("UPSERT INTO coll SELECT * FROM t PK a, b.m.x", Set("a", "x"))
+      testUpsertKeys("UPSERT INTO coll SELECT * FROM t PK b.m.x", Set("x"))
+    }
+
+    "return full keys if requested" in {
+
+      testUpsertKeys("UPSERT INTO coll SELECT * FROM t PK a", Set("a"), preserve=true)
+      testUpsertKeys("UPSERT INTO coll SELECT * FROM t PK a, b.m", Set("a", "b.m"), preserve=true)
+      testUpsertKeys("UPSERT INTO coll SELECT * FROM t PK a, b.m, b.n.x", Set("a", "b.m", "b.n.x"), preserve=true)
+      testUpsertKeys("UPSERT INTO coll SELECT * FROM t PK b.m.x", Set("b.m.x"), preserve=true)
+    }
+  }
+
+}

--- a/src/test/scala/com/datamountaineer/streamreactor/connect/config/KcqlSettingsTest.scala
+++ b/src/test/scala/com/datamountaineer/streamreactor/connect/config/KcqlSettingsTest.scala
@@ -70,6 +70,18 @@ class KcqlSettingsTest extends WordSpec with Matchers {
       testUpsertKeys("UPSERT INTO coll SELECT * FROM t PK a, b.m, b.n.x", Set("a", "b.m", "b.n.x"), preserve=true)
       testUpsertKeys("UPSERT INTO coll SELECT * FROM t PK b.m.x", Set("b.m.x"), preserve=true)
     }
+
+    "return keys in the expected order - as listed in the PK clause" in {
+
+      val kcql = "UPSERT INTO coll SELECT * FROM t PK a,b,c,d"
+      val expectedKeys = List("a","b","c","d")
+      val keys = KS(kcql).getUpsertKeys(preserveFullKeys=true)("t")
+      // SCALA 2.12 WARNING: If this fails when you upgrade to 2.12, you need to 
+      // modify KcqlSettings to remove all the reverse() calls when constructing
+      // the ListSets.
+      keys.toList shouldBe expectedKeys
+    }
+
   }
 
 }


### PR DESCRIPTION
I changed KcqlSetting key functions to return ListSets instead of plain Sets.  This has the benefit of always preserving the specified order in the PK clause from KCQL.  The underlying type returned is still Set, to maintain compatibility.  

I added some tests for the order, so that when this is upgraded to Scala 2.12, the upgrader will be alerted via a failing test that the "reverse" calls have to be removed.  (The ListSet returns backwards-ordered elements in 2.11, and it's fixed in 2.12.)

I also added support for extracting "embedded keys" to getUpsertKeys().  See the tests for the details, but it allows you to specify primary keys like "PK person.address.streetNumber", for example.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/kafka-connect-common/25)
<!-- Reviewable:end -->
